### PR TITLE
PRG should write to second part of output as well

### DIFF
--- a/dpf/dpf.go
+++ b/dpf/dpf.go
@@ -17,7 +17,7 @@ var prfR *aesPrf
 var keyL = make([]uint32, 11*4)
 var keyR = make([]uint32, 11*4)
 
-var blockStack = make([][2]*block, 63)
+//var blockStack = make([][2]*block, 63)
 
 func init() {
 	var prfkeyL = []byte{36, 156, 50, 234, 92, 230, 49, 9, 174, 170, 205, 160, 98, 236, 29, 243}
@@ -36,10 +36,10 @@ func init() {
 	//if cpu.X86.HasSSE2 == false || cpu.X86.HasAVX2 == false {
 	//	panic("we need sse2 and avx")
 	//}
-	for i := 0; i < 63; i++ {
-		blockStack[i][0] = new(block)
-		blockStack[i][1] = new(block)
-	}
+	// for i := 0; i < 63; i++ {
+	// 	blockStack[i][0] = new(block)
+	// 	blockStack[i][1] = new(block)
+	// }
 
 }
 
@@ -210,7 +210,7 @@ func Eval(k DPFkey, x uint64, logN uint64) byte {
 	}
 }
 
-func evalFullRecursive(k DPFkey, s *block, t byte, lvl uint64, stop uint64, res *bytearr) {
+func evalFullRecursive(blockStack [][2]*block, k DPFkey, s *block, t byte, lvl uint64, stop uint64, res *bytearr) {
 	if lvl == stop {
 		ss := blockStack[lvl][0]
 		*ss = *s
@@ -236,8 +236,8 @@ func evalFullRecursive(k DPFkey, s *block, t byte, lvl uint64, stop uint64, res 
 		tL ^= tLCW
 		tR ^= tRCW
 	}
-	evalFullRecursive(k, sL, tL, lvl+1, stop, res)
-	evalFullRecursive(k, sR, tR, lvl+1, stop, res)
+	evalFullRecursive(blockStack, k, sL, tL, lvl+1, stop, res)
+	evalFullRecursive(blockStack, k, sR, tR, lvl+1, stop, res)
 }
 
 func EvalFull(key DPFkey, logN uint64) []byte {
@@ -252,6 +252,11 @@ func EvalFull(key DPFkey, logN uint64) []byte {
 	}
 
 	var b = bytearr{buf, 0}
-	evalFullRecursive(key, s, t, 0, stop, &b)
+	var blockStack = make([][2]*block, 63)
+	for i := 0; i < 63; i++ {
+		blockStack[i][0] = new(block)
+		blockStack[i][1] = new(block)
+	}
+	evalFullRecursive(blockStack,key, s, t, 0, stop, &b)
 	return b.data
 }

--- a/dpf/dpf.go
+++ b/dpf/dpf.go
@@ -63,7 +63,7 @@ func prg(seed, s0, s1 *byte) (byte, byte) {
 	t0 := getT(s0)
 	clr(s0)
 	//prfR.Encrypt(s1, seed)
-	aes128MMO(&keyR[0], s0, seed)
+	aes128MMO(&keyR[0], s1, seed)
 	t1 := getT(s1)
 	clr(s1)
 	return t0, t1

--- a/dpf/dpf_test.go
+++ b/dpf/dpf_test.go
@@ -6,7 +6,7 @@ import (
 
 func BenchmarkEvalFull(bench *testing.B) {
 	logN := uint64(28)
-	a,_ := Gen(0, logN)
+	a, _ := Gen(0, logN)
 	bench.ResetTimer()
 	//fmt.Println("Ka: ", a)
 	//fmt.Println("Kb: ", b)
@@ -32,8 +32,8 @@ func BenchmarkXor16(bench *testing.B) {
 func TestEval(test *testing.T) {
 	logN := uint64(8)
 	alpha := uint64(123)
-	a,b := Gen(alpha, logN)
-	for i:= uint64(0); i < (uint64(1) << logN); i++ {
+	a, b := Gen(alpha, logN)
+	for i := uint64(0); i < (uint64(1) << logN); i++ {
 		aa := Eval(a, i, logN)
 		bb := Eval(b, i, logN)
 		if (aa^bb == 1 && i != alpha) || (aa^bb == 0 && i == alpha) {
@@ -45,12 +45,27 @@ func TestEval(test *testing.T) {
 func TestEvalFull(test *testing.T) {
 	logN := uint64(9)
 	alpha := uint64(128)
-	a,b := Gen(alpha, logN)
+	a, b := Gen(alpha, logN)
 	aa := EvalFull(a, logN)
 	bb := EvalFull(b, logN)
-	for i:= uint64(0); i < (uint64(1) << logN); i++ {
-		aaa := (aa[i/8] >> (i%8)) & 1
-		bbb := (bb[i/8] >> (i%8)) & 1
+	for i := uint64(0); i < (uint64(1) << logN); i++ {
+		aaa := (aa[i/8] >> (i % 8)) & 1
+		bbb := (bb[i/8] >> (i % 8)) & 1
+		if (aaa^bbb == 1 && i != alpha) || (aaa^bbb == 0 && i == alpha) {
+			test.Fail()
+		}
+	}
+}
+
+func TestEvalFullShort(test *testing.T) {
+	logN := uint64(3)
+	alpha := uint64(1)
+	a, b := Gen(alpha, logN)
+	aa := EvalFull(a, logN)
+	bb := EvalFull(b, logN)
+	for i := uint64(0); i < (uint64(1) << logN); i++ {
+		aaa := (aa[i/8] >> (i % 8)) & 1
+		bbb := (bb[i/8] >> (i % 8)) & 1
 		if (aaa^bbb == 1 && i != alpha) || (aaa^bbb == 0 && i == alpha) {
 			test.Fail()
 		}

--- a/dpf/dpf_test.go
+++ b/dpf/dpf_test.go
@@ -43,8 +43,8 @@ func TestEval(test *testing.T) {
 }
 
 func TestEvalFull(test *testing.T) {
-	logN := uint64(8)
-	alpha := uint64(123)
+	logN := uint64(9)
+	alpha := uint64(128)
 	a,b := Gen(alpha, logN)
 	aa := EvalFull(a, logN)
 	bb := EvalFull(b, logN)


### PR DESCRIPTION
Hi,

First of all, thanks a lot for this repository, I found it really helpful in working on a PIR project. Not sure whether you are still maintaining it, but I ran across a bug, so I figured I would offer the fix.

If I am not mistaken, I think there that the `prg` function has not been correctly writing the second part of its output (s1). 

Thanks,
Dima




P.S. Weirdly, it only manifested for me when using `EvallFull`: the blocks from the blockstack were not zeroed out at each step of the recursion, and the `prg` function was not writing the right parts because of this bug, which led to inconsistent behaviour.